### PR TITLE
bump local mysql perf

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -20,7 +20,8 @@ init-connect='SET NAMES <%= scope.lookupvar "mysql::config::charset" %> COLLATE 
 lower_case_table_names=<%= scope.lookupvar "mysql::config::casing" %>
 max_sp_recursion_depth=3
 <% if (scope.lookupvar "mysql::config::engine") == 'innodb' %>
-innodb_buffer_pool_size=50Mb
+innodb_buffer_pool_size=512Mb
+innodb_log_file_size=128Mb
 innodb_file_per_table
 innodb_file_format = Barracuda
 innodb_large_prefix


### PR DESCRIPTION
This increases dump import performance by about 10% on my machine.  Should be even higher on lower i/o performing machines.

@nonrational @andrewglenn
