### PR TITLE
mitigate: mysql on OSX throws errors with innodb_file_per_table option

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -19,6 +19,8 @@ init-connect='SET collation_connection=<%= scope.lookupvar "mysql::config::colla
 init-connect='SET NAMES <%= scope.lookupvar "mysql::config::charset" %> COLLATE <%= scope.lookupvar "mysql::config::collation" %>'
 lower_case_table_names=<%= scope.lookupvar "mysql::config::casing" %>
 max_sp_recursion_depth=3
+# https://bugs.mysql.com/bug.php?id=71960
+table_open_cache=500
 <% if (scope.lookupvar "mysql::config::engine") == 'innodb' %>
 innodb_buffer_pool_size=1024Mb
 innodb_log_file_size=128Mb


### PR DESCRIPTION
@galonsky @effron @zzma @adamlangsner @fuchse 

i've had some success with this preventing `ERROR 2013 (HY000): Lost connection to MySQL server at 'reading authorization packet', system error: 0` by setting `table_open_cache=500`.

See https://bugs.mysql.com/bug.php?id=71960

also, /cc @Betterment/fido upstream boxen/puppet-mysql has upgraded to 5.6 finally so we might consider getting back on the mainline.