### PR TITLE
Link my-default.cnf to my.cnf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,11 @@ class mysql::config(
       notify  => Service['mysql'] ;
   }
 
+  file { "${configdir}/my-default.cnf":
+    ensure => 'link',
+    target => "${configdir}/my.cnf",
+  }
+
   ->
   exec { 'init-mysql-db':
     command  => "${bindir}/mysql_install_db \


### PR DESCRIPTION
This fixes an issue from the base repo. It isn't a general solution, but works for me until this gets fixed upstream (Issue https://github.com/boxen/puppet-mysql/issues/57)

MySql install was complaining about `my-default.cnf` not being found, so symlink our `my.cnf` to `my-default.cnf` in a place that MySql can find it.

/domain @nonrational @galonsky 
/platform @galonsky 