### PR TITLE
Host tar.gz on devops S3 bucket. Revert hash change

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -1,7 +1,7 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://cdn.mysql.com/archives/mysql-5.6/mysql-5.6.29.tar.gz"
+  url "https://s3.amazonaws.com/betterment-devops/public/mysql-5.6.29.tar.gz"
   sha256 "6ac85b75b2dfa8c232725dda25469df37bf4e48b408cc0978d0dfc34c25a817f"
 
   option :universal

--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -1,8 +1,8 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.29.tar.gz"
-  sha256 "8356bba23f3f6c0c2d4806110c41d1c4d6a4b9c50825e11c5be4bbee2b20b71d"
+  url "https://cdn.mysql.com/archives/mysql-5.6/mysql-5.6.29.tar.gz"
+  sha256 "6ac85b75b2dfa8c232725dda25469df37bf4e48b408cc0978d0dfc34c25a817f"
 
   option :universal
   option "with-tests", "Build with unit tests"


### PR DESCRIPTION
/domain @rtimmons @galonsky @nonrational
/cc @gregorychen3 

This uses a different URL than the one @gregorychen3 just changed it too. But it uses the original hash, which is good cause we weren't really sure why it changed.

@gregorychen3's URL didn't work for Collin, as it redirected to the URL we changed it too, then grabbed a `tar.gz` with the original hash.

This worked locally on @ctrokid's machine
